### PR TITLE
Second version using CUDA image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,36 @@
 # syntax=docker/dockerfile:1
  
-FROM continuumio/miniconda3
+FROM nvidia/cuda:11.8.0-base-ubuntu22.04
+
+################################################################################
+# Reference miniconda dockerfile:
+#   https://hub.docker.com/r/continuumio/miniconda3/dockerfile
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH /opt/conda/bin:$PATH
+
+RUN apt-get update --fix-missing && \
+    apt-get install -y wget bzip2 ca-certificates curl git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh && \
+    /opt/conda/bin/conda clean -tipsy && \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc
+
+ENV TINI_VERSION v0.16.1
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+RUN chmod +x /usr/bin/tini
+
+#ENTRYPOINT [ "/usr/bin/tini", "--" ]
+#CMD [ "/bin/bash" ]
+
+################################################################################
+# Start InvokeAI layers
+
 SHELL ["/bin/bash", "--login", "-c"]
 
 # Prevent packages from prompting for interactive inputs.
@@ -19,9 +49,13 @@ ENV TRAINING_DIR="${INSTALL_DIR}training-data/"
 RUN apt update \
  && apt install -y \
     dos2unix \
-    git \
     libgl1 \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender1 \
     --no-install-recommends \
+ && apt clean \
  && rm -rf /var/lib/apt/lists/* \
  && conda update -n base -c defaults conda \
  && conda clean --all --yes
@@ -36,8 +70,10 @@ RUN conda env create \
  && conda init bash \
  && conda clean --all --yes
 
-# Initial setup sans models
-RUN python3 scripts/preload_models.py --no-interactive
+# Do initial setup (licensed models not are downloaded).
+RUN conda init bash \
+ && conda activate invokeai \
+ && python3 scripts/preload_models.py --no-interactive
 
 # Entry point.
 ADD start.sh .

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 VERSION=v$(date -u +%Y%m%d-%H%M%S)
 echo $VERSION
-VERSION=v0.1
+VERSION=v0.2
 
 docker build \
   -f Dockerfile \
@@ -10,5 +10,7 @@ docker build \
   -t wpafbo79/invokeai:latest \
   .
 
-time docker push wpafbo79/invokeai:$VERSION
-time docker push wpafbo79/invokeai:latest
+time ( \
+  docker push wpafbo79/invokeai:$VERSION && \
+  docker push wpafbo79/invokeai:latest \
+)


### PR DESCRIPTION
To speed up processing by using the GPU, it is necessary to use the CUDA tools.  Copy the Miniconda Dockerfile information into the local Dockerfile and then base the new image off of the CUDA image.

See: #2