### PR TITLE
Third version of the image without VOLUMEs.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 VERSION=v$(date -u +%Y%m%d-%H%M%S)
 echo $VERSION
-VERSION=v0.2
+VERSION=v0.3
 
 docker build \
   -f Dockerfile \

--- a/create-container.sh
+++ b/create-container.sh
@@ -3,20 +3,22 @@
 progname=$(basename $0)
 
 usage="
-Usage: ${progname} [-h] [-c <configsdir> -m <modelsdir> -o <outputsdir>
-       -t <trainingdir> | -b <basedir>] [-n <name>]
+Usage: ${progname} [-h] [-c <configsdir> -l <logsdir> -m <modelsdir>
+       -o <outputsdir> -t <trainingdir> | -b <basedir>] [-n <name>]
 
-  -b  Base directory that contains directories \"configs/\",
+  -b  Base directory that contains directories \"configs/\", \"logs\",
       \"models/ldm/stable-diffusion-v1/\", \"outputs/\", and \"training-data/\".
   -c  Local directory to mount to \"configs\".
   -h  Show this usage statement.
+  -l  Local directory to mount to \"logs\".
   -m  Local directory to mount to \"models\".
-  -n  Name for the container.  [Defaults:\"invokeai\"]
+  -n  Name for the container.  [Default:\"invokeai\"]
   -o  Local directory to mount to \"outputs\".
   -t  Local directory to mount to \"training\".
 
   Volumes used by container:
     - configs:/InvokeAI/configs/
+    - logs:/InvokeAI/logs/
     - models:/InvokeAI/models/ldm/stable-diffusion-v1/
     - outputs:/InvokeAI/outputs/
     - training:/InvokeAI/training-data/
@@ -24,6 +26,7 @@ Usage: ${progname} [-h] [-c <configsdir> -m <modelsdir> -o <outputsdir>
 
 optBase=""
 optConfigs=""
+optLogs=""
 optModels=""
 optName="invokeai"
 optOutputs=""
@@ -31,7 +34,7 @@ optTraining=""
 
 usage() { echo "$usage" 1>&2; exit 1; }
 
-while getopts ":b:c:hm:n:o:t:" options; do
+while getopts ":b:c:hl:m:n:o:t:" options; do
   case "${options}" in
     b)
       optBase=${OPTARG}
@@ -41,6 +44,9 @@ while getopts ":b:c:hm:n:o:t:" options; do
       ;;
     h)
       usage
+      ;;
+    l)
+      optLogs=${OPTARG}
       ;;
     m)
       optModels=${OPTARG}
@@ -66,12 +72,14 @@ shift $((OPTIND-1))
 if [[ ( \
   "$optBase" = "" && ( \
   "$optConfigs" = "" || \
+  "$optLogs" = "" || \
   "$optModels" = "" || \
   "$optOutputs" = "" || \
   "$optTraining" = "" )
   ) || \
   ( "$optBase" != "" && ( \
   "$optConfigs" != "" || \
+  "$optLogs" != "" || \
   "$optModels" != "" || \
   "$optOutputs" != "" || \
   "$optTraining" != "" ) \
@@ -81,6 +89,7 @@ fi
 
 if [ "$optBase" != "" ]; then
   optConfigs="${optBase}/configs/"
+  optLogs="${optBase}/logs/"
   optModels="${optBase}/models/ldm/stable-diffusion-v1/"
   optOutputs="${optBase}/outputs/"
   optTraining="${optBase}/training-data/"
@@ -91,6 +100,7 @@ docker run \
   --name $optName \
   -d \
   -v ${optConfigs}:/InvokeAI/configs/ \
+  -v ${optLogs}:/InvokeAI/logs/ \
   -v ${optModels}:/InvokeAI/models/ldm/stable-diffusion-v1/ \
   -v ${optOutputs}:/InvokeAI/outputs/ \
   -v ${optTraining}:/InvokeAI/training-data/ \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     restart: unless-stopped
     volumes:
       - configs:/InvokeAI/configs/
+      - logs:/InvokeAI/logs/
       - models:/InvokeAI/models/ldm/stable-diffusion-v1/
       - outputs:/InvokeAI/outputs/
       - training:/InvokeAI/training-data/
@@ -19,6 +20,8 @@ services:
 
 volumes:
   configs:
+    driver: local
+  logs:
     driver: local
   models:
     driver: local

--- a/start.sh
+++ b/start.sh
@@ -65,7 +65,13 @@ if [ $optPreload -eq 1 ]; then
   exit
 fi
 
-if [ $(ls models/ldm/stable-diffusion-v1/*.ckpt | wc -l) -eq 0 ]; then
+# Copy data from directories covered by volumes to populate volumes.
+for dir in $(ls -d archive/*); do
+  rsync -HaAxX --ignore-existing $dir/ $(basename $dir)/
+done
+
+if [ $(ls models/ldm/stable-diffusion-v1/*.ckpt | wc -l) -eq 0 -o \
+  $(ls configs/models.yaml | wc -l) -eq 0 ]; then
   cat <<EOF
 No model found!
 Please run an interactive command to download models.
@@ -84,5 +90,5 @@ EOF
   exit
 fi
 
-echo "Running InvokeAI...  (This can take few minutes.)"
+echo "Running InvokeAI...  (This can take a few minutes.)"
 python3 scripts/invoke.py --web --host=0.0.0.0


### PR DESCRIPTION
Remove VOLUMEs from Dockerfile since they aren't necessary to use volumes.  However, do keep the directory variables so that they can be used to archive the data and restore it from the start script when the volume is mounted.

Also, add the logs volume to the build script and docker-compose.yml file.

Clean up the create-container script.  Add support for the logs volume and clean up verbiage.

See: #2