### PR TITLE
Don't publish images if using a ".nopublish" file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.nopublish
 .previd

--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,7 @@ script-permissions:
           -o \
 	  -name "create-container.sh" \
 	  \) -exec git update-index --chmod=+x {} \;
+
+.PHONY: clean
+clean:
+	@find . \( -name .nopublish -o -name .previd \) -exec rm {} \;

--- a/build.common.sh
+++ b/build.common.sh
@@ -21,8 +21,15 @@ function build() {
     cut -d " " -f 3)
 
   # Push the image if it is new
-  if [ "${previd}" != "${currid}" ]; then
+  if [ -f ../.nopublish -o -f .nopublish ]; then
+    echo "\".nopublish\" detected.  Skipping upload to Docker repo."
+  elif [ "${previd}" != "${currid}" ]; then
     echo "Uploading..."
+    cat << EOF
+Bypass publishing to the Docker repo by creating ".nopublish" in the root
+directory of the repo.  If created in a subdirectory, only that image will be
+skipped.
+EOF
     time ( \
       docker push ${DOCKER_REPO}:${VERSION} && \
       docker push ${DOCKER_REPO}:latest \


### PR DESCRIPTION
Create a file in the root directory to control all images, or in a subdirectory to control individual images.

Added a "clean" Makefile target to remove the ".nopublish" and ".previd" files.

See: #41