### PR TITLE
Save Docker build output as a log.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .nopublish
 .previd
+log.*

--- a/Makefile
+++ b/Makefile
@@ -72,4 +72,10 @@ script-permissions:
 
 .PHONY: clean
 clean:
-	@find . \( -name .nopublish -o -name .previd \) -exec rm {} \;
+	@find . \( \
+	  -name .nopublish \
+	  -o \
+          -name .previd \
+	  -o \
+	  -name "log.*" \
+          \) -exec rm -v {} \;

--- a/build.common.sh
+++ b/build.common.sh
@@ -5,11 +5,13 @@ function build() {
 
   docker build \
     --no-cache \
+    --progress=plain \
     --build-arg GIT_REPO="${GIT_REPO}" \
     -f Dockerfile \
     -t ${DOCKER_REPO}:${VERSION} \
     -t ${DOCKER_REPO}:latest \
-    .
+    . 2>&1 |
+    tee log.${VERSION}
 
   touch .previd
 


### PR DESCRIPTION
Add logs to ".gitignore" and remove logs with the Makefile "clean" target.

See: #46