### PR TITLE
Make logging easier

### DIFF
--- a/build.common.sh
+++ b/build.common.sh
@@ -3,6 +3,7 @@
 function build() {
   echo ${DOCKER_REPO}:${VERSION}
 
+  DOCKER_BUILDKIT=0 \
   docker build \
     --no-cache \
     --progress=plain \
@@ -11,7 +12,7 @@ function build() {
     -t ${DOCKER_REPO}:${VERSION} \
     -t ${DOCKER_REPO}:latest \
     . 2>&1 |
-    tee log.${VERSION}
+  tee log.${VERSION}
 
   touch .previd
 


### PR DESCRIPTION
Set DOCKER_BUILDKIT environment variable to make output better for logging and to show intermediate image hash values.

See: #46