### PR TITLE
Add invokeai-xformers to the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ GFPGAN_PROJECTS := \
 STABLE_DIFFUSION_PROJECTS := \
 	basujindal-stable-diffusion \
 	compvis-stable-diffusion \
-	invokeai
+	invokeai \
+	invokeai-xformers
 
 BASE_COMPOSE := $(addsuffix -compose, $(BASE_PROJECTS))
 BASE_IMAGES := $(addsuffix -images, $(BASE_PROJECTS))


### PR DESCRIPTION
Allow the global build of images to also build the InvokeAI xformers image.

See: #34