### PR TITLE
Improve build checks to detect when to build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.*.md5
 .nopublish
+.prevdigest
 .previd
 log.*

--- a/Makefile
+++ b/Makefile
@@ -91,5 +91,9 @@ clean:
 .PHONY: veryclean
 veryclean: clean
 	@find . \( \
+          -name .*.md5 \
+	  -o \
+          -name .prevdigest \
+	  -o \
           -name .previd \
           \) -exec rm -v {} \;


### PR DESCRIPTION
Use checksums to determine when files have changed since the last build so that the image can be rebuilt.  Timestamps don't work well when the timestamp changes with branch changes that remove/add the files in between builds.  Also, check the against the latest published base image to see if that changed.

See: #83